### PR TITLE
Update runtime to 40

### DIFF
--- a/com.github.maoschanz.DynamicWallpaperEditor.json
+++ b/com.github.maoschanz.DynamicWallpaperEditor.json
@@ -1,7 +1,7 @@
 {
 	"app-id" : "com.github.maoschanz.DynamicWallpaperEditor",
 	"runtime" : "org.gnome.Platform",
-	"runtime-version" : "3.36",
+	"runtime-version" : "40",
 	"sdk" : "org.gnome.Sdk",
 	"command" : "dynamic-wallpaper-editor",
 	"finish-args" : [


### PR DESCRIPTION
`org.gnome.Platform` 3.36 is end of life.

I didn't really do that much testing with this to be honest, but I don't know if there's much of anything that could break here.