### PR TITLE
Bump the runtime to the latest 42 version

### DIFF
--- a/com.github.maoschanz.DynamicWallpaperEditor.json
+++ b/com.github.maoschanz.DynamicWallpaperEditor.json
@@ -1,7 +1,7 @@
 {
 	"app-id" : "com.github.maoschanz.DynamicWallpaperEditor",
 	"runtime" : "org.gnome.Platform",
-	"runtime-version" : "40",
+	"runtime-version" : "42",
 	"sdk" : "org.gnome.Sdk",
 	"command" : "dynamic-wallpaper-editor",
 	"finish-args" : [


### PR DESCRIPTION
The GNOME runtime version 40 is now deprecated.